### PR TITLE
Add initial event schemas and JSON serialization utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## v1.0.0
+- Initial release with core event schemas, event classes, JSON serialization utilities, and basic tests.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.car.marketplace</groupId>
+    <artifactId>common-messaging</artifactId>
+    <version>1.0.0</version>
+    <name>Common Messaging Library</name>
+    <description>Shared event schemas and utilities for the Car Services Marketplace</description>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.10.2</junit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.16.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>3.6.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/schemas/order-created.json
+++ b/schemas/order-created.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OrderCreated",
+  "type": "object",
+  "properties": {
+    "eventId": { "type": "string", "format": "uuid" },
+    "occurredAt": { "type": "string", "format": "date-time" },
+    "aggregateId": { "type": "string", "format": "uuid" },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "customerId": { "type": "string", "format": "uuid" },
+        "providerId": { "type": "string", "format": "uuid" },
+        "serviceTag": { "type": "string" },
+        "scheduledAt": { "type": "string", "format": "date-time" }
+      },
+      "required": ["customerId", "providerId", "serviceTag", "scheduledAt"]
+    }
+  },
+  "required": ["eventId", "occurredAt", "aggregateId", "payload"]
+}

--- a/schemas/payment-intent-created.json
+++ b/schemas/payment-intent-created.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PaymentIntentCreated",
+  "type": "object",
+  "properties": {
+    "eventId": { "type": "string", "format": "uuid" },
+    "occurredAt": { "type": "string", "format": "date-time" },
+    "aggregateId": { "type": "string", "format": "uuid" },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "orderId": { "type": "string", "format": "uuid" },
+        "amount": {
+          "type": "object",
+          "properties": {
+            "currency": { "type": "string" },
+            "value": { "type": "number" }
+          },
+          "required": ["currency", "value"]
+        }
+      },
+      "required": ["orderId", "amount"]
+    }
+  },
+  "required": ["eventId", "occurredAt", "aggregateId", "payload"]
+}

--- a/schemas/provider-registered.json
+++ b/schemas/provider-registered.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ProviderRegistered",
+  "type": "object",
+  "properties": {
+    "eventId": { "type": "string", "format": "uuid" },
+    "occurredAt": { "type": "string", "format": "date-time" },
+    "aggregateId": { "type": "string", "format": "uuid" },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "phone": { "type": "string" },
+        "address": { "type": "string" },
+        "location": {
+          "type": "object",
+          "properties": {
+            "latitude": { "type": "number" },
+            "longitude": { "type": "number" }
+          },
+          "required": ["latitude", "longitude"]
+        },
+        "serviceTags": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "required": ["name", "phone", "address", "location", "serviceTags"]
+    }
+  },
+  "required": ["eventId", "occurredAt", "aggregateId", "payload"]
+}

--- a/src/main/java/com/car/marketplace/common/messaging/domain/GeoPoint.java
+++ b/src/main/java/com/car/marketplace/common/messaging/domain/GeoPoint.java
@@ -1,0 +1,3 @@
+package com.car.marketplace.common.messaging.domain;
+
+public record GeoPoint(double latitude, double longitude) {}

--- a/src/main/java/com/car/marketplace/common/messaging/domain/Money.java
+++ b/src/main/java/com/car/marketplace/common/messaging/domain/Money.java
@@ -1,0 +1,5 @@
+package com.car.marketplace.common.messaging.domain;
+
+import java.math.BigDecimal;
+
+public record Money(BigDecimal value, String currency) {}

--- a/src/main/java/com/car/marketplace/common/messaging/domain/ServiceTag.java
+++ b/src/main/java/com/car/marketplace/common/messaging/domain/ServiceTag.java
@@ -1,0 +1,6 @@
+package com.car.marketplace.common.messaging.domain;
+
+public enum ServiceTag {
+    OIL_CHANGE,
+    TIRE_ROTATION
+}

--- a/src/main/java/com/car/marketplace/common/messaging/event/DomainEvent.java
+++ b/src/main/java/com/car/marketplace/common/messaging/event/DomainEvent.java
@@ -1,0 +1,10 @@
+package com.car.marketplace.common.messaging.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public interface DomainEvent {
+    UUID eventId();
+    Instant occurredAt();
+    UUID aggregateId();
+}

--- a/src/main/java/com/car/marketplace/common/messaging/event/order/OrderCreated.java
+++ b/src/main/java/com/car/marketplace/common/messaging/event/order/OrderCreated.java
@@ -1,0 +1,22 @@
+package com.car.marketplace.common.messaging.event.order;
+
+import com.car.marketplace.common.messaging.domain.ServiceTag;
+import com.car.marketplace.common.messaging.event.DomainEvent;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record OrderCreated(
+        UUID eventId,
+        Instant occurredAt,
+        UUID aggregateId,
+        Payload payload
+) implements DomainEvent {
+
+    public record Payload(
+            UUID customerId,
+            UUID providerId,
+            ServiceTag serviceTag,
+            Instant scheduledAt
+    ) {}
+}

--- a/src/main/java/com/car/marketplace/common/messaging/event/payment/PaymentIntentCreated.java
+++ b/src/main/java/com/car/marketplace/common/messaging/event/payment/PaymentIntentCreated.java
@@ -1,0 +1,20 @@
+package com.car.marketplace.common.messaging.event.payment;
+
+import com.car.marketplace.common.messaging.domain.Money;
+import com.car.marketplace.common.messaging.event.DomainEvent;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record PaymentIntentCreated(
+        UUID eventId,
+        Instant occurredAt,
+        UUID aggregateId,
+        Payload payload
+) implements DomainEvent {
+
+    public record Payload(
+            UUID orderId,
+            Money amount
+    ) {}
+}

--- a/src/main/java/com/car/marketplace/common/messaging/event/provider/ProviderRegistered.java
+++ b/src/main/java/com/car/marketplace/common/messaging/event/provider/ProviderRegistered.java
@@ -1,0 +1,25 @@
+package com.car.marketplace.common.messaging.event.provider;
+
+import com.car.marketplace.common.messaging.domain.GeoPoint;
+import com.car.marketplace.common.messaging.domain.ServiceTag;
+import com.car.marketplace.common.messaging.event.DomainEvent;
+
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+
+public record ProviderRegistered(
+        UUID eventId,
+        Instant occurredAt,
+        UUID aggregateId,
+        Payload payload
+) implements DomainEvent {
+
+    public record Payload(
+            String name,
+            String phone,
+            String address,
+            GeoPoint location,
+            Set<ServiceTag> serviceTags
+    ) {}
+}

--- a/src/main/java/com/car/marketplace/common/messaging/serialization/JsonEventDeserializer.java
+++ b/src/main/java/com/car/marketplace/common/messaging/serialization/JsonEventDeserializer.java
@@ -1,0 +1,48 @@
+package com.car.marketplace.common.messaging.serialization;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class JsonEventDeserializer<T> implements Deserializer<T> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private Class<T> targetType;
+
+    public JsonEventDeserializer() {
+    }
+
+    public JsonEventDeserializer(Class<T> targetType) {
+        this.targetType = targetType;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        if (targetType == null) {
+            Object typeName = configs.get("value.deserializer.type");
+            if (typeName instanceof String s) {
+                try {
+                    this.targetType = (Class<T>) Class.forName(s);
+                } catch (ClassNotFoundException e) {
+                    throw new SerializationException("Unknown class: " + s, e);
+                }
+            }
+        }
+    }
+
+    @Override
+    public T deserialize(String topic, byte[] data) {
+        if (data == null) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(data, targetType);
+        } catch (IOException e) {
+            throw new SerializationException("Error deserializing event", e);
+        }
+    }
+}

--- a/src/main/java/com/car/marketplace/common/messaging/serialization/JsonEventSerializer.java
+++ b/src/main/java/com/car/marketplace/common/messaging/serialization/JsonEventSerializer.java
@@ -1,0 +1,23 @@
+package com.car.marketplace.common.messaging.serialization;
+
+import com.car.marketplace.common.messaging.event.DomainEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Serializer;
+
+public class JsonEventSerializer implements Serializer<DomainEvent> {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public byte[] serialize(String topic, DomainEvent data) {
+        if (data == null) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsBytes(data);
+        } catch (JsonProcessingException e) {
+            throw new SerializationException("Error serializing event", e);
+        }
+    }
+}

--- a/src/test/java/com/car/marketplace/common/messaging/serialization/JsonEventSerdeTest.java
+++ b/src/test/java/com/car/marketplace/common/messaging/serialization/JsonEventSerdeTest.java
@@ -1,0 +1,39 @@
+package com.car.marketplace.common.messaging.serialization;
+
+import com.car.marketplace.common.messaging.domain.GeoPoint;
+import com.car.marketplace.common.messaging.domain.ServiceTag;
+import com.car.marketplace.common.messaging.event.provider.ProviderRegistered;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JsonEventSerdeTest {
+
+    @Test
+    void roundTripProviderRegistered() {
+        ProviderRegistered event = new ProviderRegistered(
+                UUID.randomUUID(),
+                Instant.now(),
+                UUID.randomUUID(),
+                new ProviderRegistered.Payload(
+                        "Auto Service Pro",
+                        "+12025550123",
+                        "123 Main St",
+                        new GeoPoint(40.7128, -74.0060),
+                        Set.of(ServiceTag.OIL_CHANGE)
+                )
+        );
+
+        JsonEventSerializer serializer = new JsonEventSerializer();
+        JsonEventDeserializer<ProviderRegistered> deserializer = new JsonEventDeserializer<>(ProviderRegistered.class);
+
+        byte[] bytes = serializer.serialize("providers", event);
+        ProviderRegistered result = deserializer.deserialize("providers", bytes);
+
+        assertEquals(event, result);
+    }
+}


### PR DESCRIPTION
## Summary
- define canonical event schemas for provider, order, and payment intent events
- add domain records and typed event classes
- implement JSON serializer/deserializer with round-trip test

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afc6658d0c832cafb16df674bca2b1